### PR TITLE
Fix for Issue #5 UnicodeDecodeError when initializing HanziDecomposer

### DIFF
--- a/hanzipy/decomposer.py
+++ b/hanzipy/decomposer.py
@@ -28,7 +28,7 @@ class HanziDecomposer:
     ):
         # Reading in cjk_decomp - Decomposition Database
         decomp_filepath = "{}/data/cjk_decomp.txt".format(CURRENT_DIR)
-        with open(decomp_filepath, encoding='utf-8') as decomp_file:
+        with open(decomp_filepath, encoding="utf-8") as decomp_file:
             lines = decomp_file.readlines()
 
             for line in lines:
@@ -48,14 +48,14 @@ class HanziDecomposer:
 
         # Reading in radical list
         radical_filepath = "{}/data/radical_with_meanings.json".format(CURRENT_DIR)
-        with open(radical_filepath, encoding='utf-8') as radicals_file:
+        with open(radical_filepath, encoding="utf-8") as radicals_file:
             self.radicals = json.load(radicals_file)
 
     def compile_all_components(
         self,
     ):
         filepath = "{}/data/chinese_charfreq_simpl_trad.csv".format(CURRENT_DIR)
-        with open(filepath, encoding='utf-8') as freq_file:
+        with open(filepath, encoding="utf-8") as freq_file:
             csvreader = csv.reader(freq_file)
             next(csvreader, None)  # skip the headers
 

--- a/hanzipy/decomposer.py
+++ b/hanzipy/decomposer.py
@@ -28,7 +28,7 @@ class HanziDecomposer:
     ):
         # Reading in cjk_decomp - Decomposition Database
         decomp_filepath = "{}/data/cjk_decomp.txt".format(CURRENT_DIR)
-        with open(decomp_filepath) as decomp_file:
+        with open(decomp_filepath, encoding='utf-8') as decomp_file:
             lines = decomp_file.readlines()
 
             for line in lines:
@@ -48,14 +48,14 @@ class HanziDecomposer:
 
         # Reading in radical list
         radical_filepath = "{}/data/radical_with_meanings.json".format(CURRENT_DIR)
-        with open(radical_filepath) as radicals_file:
+        with open(radical_filepath, encoding='utf-8') as radicals_file:
             self.radicals = json.load(radicals_file)
 
     def compile_all_components(
         self,
     ):
         filepath = "{}/data/chinese_charfreq_simpl_trad.csv".format(CURRENT_DIR)
-        with open(filepath) as freq_file:
+        with open(filepath, encoding='utf-8') as freq_file:
             csvreader = csv.reader(freq_file)
             next(csvreader, None)  # skip the headers
 

--- a/hanzipy/dictionary.py
+++ b/hanzipy/dictionary.py
@@ -51,7 +51,7 @@ class HanziDictionary:
 
         ccedict_filepath = "{}/data/cedict_ts.u8".format(CURRENT_DIR)
 
-        with open(ccedict_filepath, encoding='utf-8') as ccedict_file:
+        with open(ccedict_filepath, encoding="utf-8") as ccedict_file:
             lines = ccedict_file.readlines()
             self.load_frequency_data()
 
@@ -301,7 +301,7 @@ class HanziDictionary:
             CURRENT_DIR
         )  # noqa
 
-        with open(leiden_freq, encoding='utf-8') as leiden_freq_file:
+        with open(leiden_freq, encoding="utf-8") as leiden_freq_file:
             lines = leiden_freq_file.readlines()
 
             for line in lines:
@@ -311,7 +311,7 @@ class HanziDictionary:
                 freq = splits[1]
                 self.word_freq[word] = freq
 
-        with open(leiden_freq_no_variants, encoding='utf-8') as leiden_freq_no_variants_file:
+        with open(leiden_freq_no_variants, encoding="utf-8") as leiden_freq_no_variants_file:
             lines = leiden_freq_no_variants_file.readlines()
 
             for line in lines:
@@ -336,7 +336,7 @@ class HanziDictionary:
     def load_irregular_phonetics(self):
         irregular_phonetics = "{}/data/irregular_phonetics.txt".format(CURRENT_DIR)
 
-        with open(irregular_phonetics, encoding='utf-8') as irregular_phonetics_file:
+        with open(irregular_phonetics, encoding="utf-8") as irregular_phonetics_file:
             lines = irregular_phonetics_file.readlines()
             for line in lines:
                 line = line.rstrip("\r\n")

--- a/hanzipy/dictionary.py
+++ b/hanzipy/dictionary.py
@@ -51,7 +51,7 @@ class HanziDictionary:
 
         ccedict_filepath = "{}/data/cedict_ts.u8".format(CURRENT_DIR)
 
-        with open(ccedict_filepath) as ccedict_file:
+        with open(ccedict_filepath, encoding='utf-8') as ccedict_file:
             lines = ccedict_file.readlines()
             self.load_frequency_data()
 
@@ -301,7 +301,7 @@ class HanziDictionary:
             CURRENT_DIR
         )  # noqa
 
-        with open(leiden_freq) as leiden_freq_file:
+        with open(leiden_freq, encoding='utf-8') as leiden_freq_file:
             lines = leiden_freq_file.readlines()
 
             for line in lines:
@@ -311,7 +311,7 @@ class HanziDictionary:
                 freq = splits[1]
                 self.word_freq[word] = freq
 
-        with open(leiden_freq_no_variants) as leiden_freq_no_variants_file:
+        with open(leiden_freq_no_variants, encoding='utf-8') as leiden_freq_no_variants_file:
             lines = leiden_freq_no_variants_file.readlines()
 
             for line in lines:
@@ -336,7 +336,7 @@ class HanziDictionary:
     def load_irregular_phonetics(self):
         irregular_phonetics = "{}/data/irregular_phonetics.txt".format(CURRENT_DIR)
 
-        with open(irregular_phonetics) as irregular_phonetics_file:
+        with open(irregular_phonetics, encoding='utf-8') as irregular_phonetics_file:
             lines = irregular_phonetics_file.readlines()
             for line in lines:
                 line = line.rstrip("\r\n")

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="昆汀",
     author_email="synkx@hotmail.fr",
     description=DESCRIPTION,
-    long_description=open('README.md', encoding='utf-8').read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type='text/markdown',
     url="https://github.com/Synkied/hanzipy",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="昆汀",
     author_email="synkx@hotmail.fr",
     description=DESCRIPTION,
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     url="https://github.com/Synkied/hanzipy",
     packages=find_packages(),


### PR DESCRIPTION
I've made some modifications to decomposer.py, dictionary.py, and setup.py to fix a UnicodeDecodeError that was occurring when HanziDecomposer was initialized.

The error was being caused by an inability to correctly handle certain Unicode characters when loading a Unicode files on the systems using an English version of Windows, this is likely cp1252

Here are the details of the changes made:

decomposer.py: Modified the file loading process to handle the file as UTF-8 encoded. This ensures that all Unicode characters in the file are correctly interpreted.

setup.py and dictionary.py: Made similar changes here to correctly handle Unicode characters.

These changes have resolved the UnicodeDecodeError on my end. I suggest merging these changes to prevent this issue from affecting other users.